### PR TITLE
Alert on check function exceptions.

### DIFF
--- a/Alertinator.php
+++ b/Alertinator.php
@@ -42,6 +42,13 @@ class Alertinator {
       $this->alertees = $config['alertees'];
    }
 
+   /**
+    * Run through every check, alerting the appropriate alertees on check
+    * failure.
+    *
+    * :raises Exception: Rethrows any non-expected Exceptions thrown in the
+    *                    checks.
+    */
    public function check() {
       foreach ($this->checks as $check => $alerteeGroups) {
          try {
@@ -56,6 +63,8 @@ class Alertinator {
                new AlertinatorCriticalException($message),
                $alerteeGroups
             );
+            // Rethrow so your standard exception handler also gets it.
+            throw $e;
          }
       }
    }

--- a/AlertinatorTest.php
+++ b/AlertinatorTest.php
@@ -160,6 +160,10 @@ class AlertinatorTest extends PHPUnit_Framework_TestCase {
       );
    }
 
+   /**
+    * @expectedException         PHPUnit_Framework_Error_Notice
+    * @expectedExceptionMessage  Use of undefined constant sdf - assumed 'sdf'
+    */
    public function test_check_errors() {
       $alertinator = new AlertinatorMocker([
          'twilio' => ['fromNumber' => '1234567890'],

--- a/docs/Alertinator.rst
+++ b/docs/Alertinator.rst
@@ -47,6 +47,12 @@ Alertinator API Docs
 
    .. php:method:: Alertinator::check()
 
+      Run through every check, alerting the appropriate alertees on check
+      failure.
+
+      :raises Exception: Rethrows any non-expected Exceptions thrown in the
+                         checks.
+
    .. php:method:: Alertinator::alertGroups()
 
    .. php:method:: Alertinator::extractAlertees()


### PR DESCRIPTION
One of the biggest concerns with alerting, monitoring, and
error-handling software is a problem in the software of the type it's
meant to prevent - who watches the watchmen?

This improves that situation a bit for Alertinator; if there is an
`Exception` thrown in one of your alert-checkers (other than an
`AlertinatorException`, which is expected), we'll treat it as a
CRITICAL-level problem, and alert you as such.

Since PHP didn't get object-orientation until late in life, it has the
notion of _errors_ in addition to _Exceptions_.  We won't catch any
errors here, unless you've set up an `error_handler` to convert those
errors into (Error)Exceptions.
