### PR TITLE
Expand Travis PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: php
 php:
   - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
 script: phpunit AlertinatorTest.php


### PR DESCRIPTION
We should run tests against other versions of PHP than just 5.4, so we
can detect issues before trying to upgrade to one of them.  I don't want
to support earlier versions, though, because then we'll lose the short
array syntax. :)
