### PR TITLE
Internal failure: Change to warning

### DIFF
--- a/Alertinator.php
+++ b/Alertinator.php
@@ -60,7 +60,7 @@ class Alertinator {
             // know about it.
             $message = "Internal failure in check:\n" . $e->getMessage();
             $this->alertGroups(
-               new AlertinatorCriticalException($message),
+               new AlertinatorWarningException($message),
                $alerteeGroups
             );
             // Rethrow so your standard exception handler also gets it.


### PR DESCRIPTION
While it's certainly nice to hear about failures when performing
monitoring checks, they don't need to be critical warnings that
could potentially result in phone calls. A warning will suffice.