### PR TITLE
Fixes #6: prevent multiples of the same alert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+# Handle git submodules yourself
+git:
+    submodules: false
+# See: https://gist.github.com/iedemam/9830045
+before_install:
+    - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+    - git submodule update --init --recursive
 language: php
 php:
   - 5.4

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -87,6 +87,10 @@ class Alertinator {
       }
    }
    
+   /**
+    * Threshold notification: determine if an all-clear alert should be sent,
+    * and if so, send it and reset the logger.
+   */
    private function notifyClear($check, $alertAfter, $clearAfter, $alerteeGroups) {
       $log = $this->logger->readAlerts($check);
       krsort($log);
@@ -123,7 +127,11 @@ class Alertinator {
          }
       }
    }
-      
+    
+   /**
+    * Threshold notification: determine if a failure alert should be sent, and
+    * if so, send it.
+   */  
    private function notifyFailure($check, $alertAfter, $alerteeGroups, $e) {
       $log = $this->logger->readAlerts($check);
       $fails = 0;
@@ -178,6 +186,9 @@ class Alertinator {
       }
    }
    
+   /**
+    * We sometimes need to modify the Exception's message for threshold alerts.
+   */
    private function prependExceptionMessage($e, $newMessage) {
       $oldMsg = $e->getMessage();
       $newMsg = $newMessage . $oldMsg;
@@ -261,6 +272,13 @@ interface alertLogger {
 
 class fileLogger implements alertLogger {
    
+   /**
+    * Write an alert to the logger.
+    *
+    * @param $name string  The key of the alert. Usually the name of the check fn.
+    * @param $status bool  0 = fail, 1 = success
+    * @param $ts int  Unix Timestamp of the event.
+   */
    public function writeAlert($name, $status, $ts = FALSE) {
       $ts = $ts ? $ts : time();
       $log = $this->readAlerts($name);
@@ -279,6 +297,9 @@ class fileLogger implements alertLogger {
       fclose($fp); 
    }
    
+   /**
+    * Return all alerts for a given key.
+   */
    public function readAlerts($name) {
       $log = array();
       if (file_exists($this->getLogFileName($name))) {
@@ -288,12 +309,18 @@ class fileLogger implements alertLogger {
       return $log;
    }
    
+   /**
+    * Reset all alerts for a given key.
+   */
    public function resetAlerts($name) {
       if(!unlink($this->getLogFileName($name))) {
          throw new Exception("Could not reset log file " . $this->getLogFileName($name) . "!");
       }
    }
    
+   /**
+    * Determine if there's at least one failure recorded.
+   */
    public function isInAlert($name) {
       return count($this->readAlerts($name));
    }

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -35,11 +35,13 @@ class Alertinator {
 
    protected $_twilio;
 
-   public function __construct($config) {
+   public function __construct($config, alertLogger $logger = NULL) {
       $this->twilio = $config['twilio'];
       $this->checks = $config['checks'];
       $this->groups = $config['groups'];
       $this->alertees = $config['alertees'];
+      $this->logger = $logger ? $logger : new fileLogger();
+      
    }
 
    /**
@@ -50,11 +52,27 @@ class Alertinator {
     *                    checks.
     */
    public function check() {
-      foreach ($this->checks as $check => $alerteeGroups) {
+      foreach ($this->checks as $check => $properties) {
+         // For compatibility with old-style (short style?) check declaration,
+         // determine if *After properties were defined.
+         $alertAfter = !empty($properties['alertAfter']) ? $properties['alertAfter'] : 0;
+         $clearAfter = !empty($properties['clearAfter']) ? $properties['clearAfter'] : 0;
+         $alerteeGroups = !empty($properties['groups']) ? $properties['groups'] : $properties;
+         
          try {
             call_user_func($check);
+            if ($clearAfter && $this->logger->isInAlert($check)) {
+               $this->logger->writeAlert($check, 1, time());
+               $this->notifyClear($check, $alertAfter, $clearAfter, $alerteeGroups);
+            }
          } catch (AlertinatorException $e) {
-            $this->alertGroups($e, $alerteeGroups);
+            if ($alertAfter) {
+               $this->logger->writeAlert($check, 0, time());
+               $this->notifyFailure($check, $alertAfter, $alerteeGroups, $e);
+            }
+            else {
+               $this->alertGroups($e, $alerteeGroups);
+            }
          } catch (Exception $e) {
             // If there's an error in your check functions, you damn better
             // know about it.
@@ -68,7 +86,53 @@ class Alertinator {
          }
       }
    }
-
+   
+   private function notifyClear($check, $alertAfter, $clearAfter, $alerteeGroups) {
+      $log = $this->logger->readAlerts($check);
+      krsort($log);
+      
+      // We only get here if there was at least 1 failure, but 1 failure may not
+      // exceed the alertAfter threshold. If the check succeeds without
+      // reaching the alert threshold, reset the log silently.
+      // TODO: this will break terribly for bouncing errors, e.g. pass-> fail->
+      //       pass-> fail-> pass-> fail. Account for this.
+      if (count($log) < $alertAfter) {
+         $this->logger->resetAlerts($check);
+         return;
+      }
+      
+      if (count($log) >= $clearAfter) {
+         $clears = 0;
+         // Only notify a clear if the check passes > $clearAfter in a row.
+         foreach($log as $ts => $alert) {
+            if (!$alert['status']) {
+               break;
+            }
+            $clears++;
+         }
+         if ($clears >= $clearAfter) {
+            $message = "The alert '$check' was cleared at " . date(DATE_RFC2822, key(reset($log))) . ".";
+            $this->alertGroups($message, $alerteeGroups);
+            $this->resetLog($check);
+         }
+      }
+   }
+      
+   private function notifyFailure($check, $alertAfter, $alerteeGroups, $e) {
+      $log = $this->logger->readAlerts($check);
+      krsort($log);
+      $fails = 0;
+      foreach ($log as $ts => $alert) {
+         if (!$alert['status']) {
+            $fails++;
+         }
+      }
+      if ($fails >= $alertAfter) {
+         $e = "Threshold of $alertAfter reached at " . date(DATE_RFC2822, key(reset($log))) . ": " . $e;
+         $this->alertGroups($e, $alerteeGroups);  
+      }
+   }
+   
    protected function alertGroups($exception, $alerteeGroups) {
       $alertees = $this->extractAlertees($alerteeGroups);
       foreach ($alertees as $alertee) {
@@ -174,3 +238,58 @@ class Alertinator {
    }
 }
 
+interface alertLogger {
+   public function writeAlert($name, $status, $ts);
+   public function readAlerts($name);
+   public function resetAlerts($name);
+   public function isInAlert($name);
+}
+
+class fileLogger implements alertLogger {
+   
+   public function writeAlert($name, $status, $ts = FALSE) {
+      $ts = $ts ? $ts : time();
+      $log = $this->readAlerts($name);
+      
+      $alert = [$ts => [
+                          'status' => $status,
+                          'check' => $name,
+                          ],
+              ];
+      
+      $log += $alert;
+      if (!$fp = fopen($this->getLogFileName($name), 'w')) {
+         throw new Exception("Could not open log file " . $this->getLogFileName($name) . " for writing.");
+      }
+      fwrite($fp, json_encode($log));
+      fclose($fp); 
+   }
+   
+   public function readAlerts($name) {
+      $log = array();
+      if (file_exists($this->getLogFileName($name))) {
+         $prevLog = file_get_contents($this->getLogFileName($name));
+         $log = json_decode($prevLog, true);  
+      }
+      return $log;
+   }
+   
+   public function resetAlerts($name) {
+      if(!unlink($this->getLogFileName($name))) {
+         throw new Exception("Could not reset log file " . $this->getLogFileName($name) . "!");
+      }
+   }
+   
+   public function isInAlert($name) {
+      return count($this->readAlerts($name));
+   }
+   
+   private function getLogFileName($name) {
+      $file = strtolower(mb_ereg_replace("([^\w\s\d\-_~,;:\[\]\(\).])", '', $name));
+      return $this->getTmpDir() . '/' . $file . '.log';
+   }
+   
+   private function getTmpDir() {
+      return ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir();
+   }
+}

--- a/AlertinatorTest.php
+++ b/AlertinatorTest.php
@@ -159,6 +159,59 @@ class AlertinatorTest extends PHPUnit_Framework_TestCase {
          [new AlertinatorWarningException('foobaz'), $alertees]
       );
    }
+   
+   public function test_error_thresholds() {
+      $alertinator = new AlertinatorMocker([
+         'twilio' => ['fromNumber' => '1234567890'],
+         'checks' => [
+            'AlertinatorTest::thresholdChecker' => [
+               'groups' => ['default'],
+               'alertAfter' => 5,
+               'clearAfter' => 2,
+               ],
+            ],
+         'groups' => ['default' => ['alice']],
+         'alertees' => [
+            'alice' => ['email' => ['alice@example.com', Alertinator::CRITICAL]],
+         ],
+      ]);
+      $this->expectOutputString('');
+      $alertinator->check();
+      
+      //$this->expectOutputString('POOP');
+      //$alertinator->check();
+      
+      
+      //$this->expectOutputEquals(
+      //   "",
+      //   [new AlertinatorWarningException('foobaz')]
+      //);
+      
+      //$this->expectOutputEquals(
+      //   "",
+      //   [$alertinator, 'check']
+      //);
+      //
+      //$this->expectOutputEquals(
+      //   "",
+      //   [$alertinator, 'check']
+      //);
+      //
+      //$this->expectOutputEquals(
+      //   "",
+      //   [$alertinator, 'check']
+      //);
+      //
+      //$this->expectOutputEquals(
+      //   "Sending message to alice@example.com via email.\n",
+      //   [$alertinator, 'check']
+      //);
+      //
+      //$this->expectOutputEquals(
+      //   "Sending message to alice@example.com via email.\n",
+      //   [$alertinator, 'check']
+      //);
+   }
 
    /**
     * @expectedException         PHPUnit_Framework_Error_Notice
@@ -180,6 +233,12 @@ class AlertinatorTest extends PHPUnit_Framework_TestCase {
          "Sending message $message to alice@example.com via email.\n",
          [$alertinator, 'check']
       );
+   }
+   
+   public static function thresholdChecker() {
+      //static $i = 1;
+      throw new AlertinatorCriticalException('foobaz');
+      
    }
 
    /**

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ reasonable subset of features at a fraction of the cost.
     ];
     (new Alertinator($config))->check();
 
+For more advanced usage, including using alert thresholds, see the [user guide](https://github.com/ifixit/alertinator/blob/master/docs/user_guide.rst).
+
 ## License
 
 Alertinator is available under the LGPL 3.0, which means that while any code

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -50,14 +50,9 @@ money (the Twilio integration) - it's easy to swap it out for an alternative,
 or even ignore it altogether.
 
 An :class:`Alertinator` is constructed with one argument, a nested associative
-array containing all the information about your alerting system.  Due to PHP's
-lack of support for `splatting`_ parameters, the single-array method was chosen
-to provide the greatest calling flexibility - you can construct it piece by
-piece or all in one go.
+array containing all the information about your alerting system:
 
 ``$config`` consists of four parts:
-
-.. _splatting: https://endofline.wordpress.com/2011/01/21/the-strange-ruby-splat/
 
 Twilio
 ^^^^^^
@@ -89,8 +84,12 @@ Checks
 ^^^^^^
 
 ``checks`` determines which alerts are checked and to whom notifications are
-sent.
+sent. Optionally, you can define an alert threshold (useful for twitchy checks).
+If you define an alert threshold, you should also define an all-clear threshold.
+If you use thresholds, an alert logger will be used for alert persistence. More
+information on the logger interface is in a section below.
 
+    // Simple implementation:
     'checks' => [
        'checkDB' => ['ops', 'devs'],
     ],
@@ -99,6 +98,20 @@ In this case, ``checkDB`` is a global function that throws an
 :class:`AlertinatorException` when some alerting threshold is passed.  When
 that happens, the alert will be sent out to members of the ``ops`` and ``devs``
 :ref:`groups`.
+
+    // Complex implementation, with alert thresholds:
+    'checks' => [
+      'checkDB' => [
+         'groups' => ['ops'],
+         'alertAfter' => 5,
+         'clearAfter' => 2,
+         ],
+      ],
+
+In this case, ``checkDB`` is still the check function, and when the alert
+exception is thrown, the alert will be sent to the ``ops`` group after the
+``afterAlert`` threshold is met. Also, once the check passes ``clearAfter``
+times in a row, an all-clear alert will be sent.
 
 It's not necessarily a good idea to use global function for your alerts.
 Correspondingly, alert names can be any PHP `callable`_, e.g.
@@ -166,9 +179,8 @@ this::
 We've extended :class:`Alertinator` to add this method::
 
     class AlertChecker extends Alertinator {
-       /**
-        * Send $message to $recipient via DevChat.
-        */
+       
+       // Send $message to $recipient via DevChat. 
        protected function devChatAnnounce($recipient, $message) {
           // Code here.
        }
@@ -177,3 +189,35 @@ We've extended :class:`Alertinator` to add this method::
 And we construct and call ``alert()`` on our ``AlertChecker`` class instead of
 :class:`Alertinator` directly.
 
+Notification thresholds
+^^^^^^^^
+
+Notification thresholds are definable on a per-check level. As in the example
+above, you define your thresholds like this:
+
+    // With alert thresholds:
+    'checks' => [
+      'checkDB' => [
+         'groups' => ['ops'],
+         'alertAfter' => 5,
+         'clearAfter' => 2,
+         ],
+      ],
+      
+``alertAfter``: send alerts after this many sequential failures. This is counted
+in a row: any successes on the same check before the alert threshold is met will
+reset the alert counter silently.
+
+``clearAfter``: send an all-clear message after this many sequential successes.
+Note: the all-clear message will send at the ``AlertinatorCriticalException``
+level, no matter what level the initial exception was.
+
+Alert persistence adaptor
+^^^^^^^^
+
+Using alert thresholds requires a persistence layer. Alertinator by default uses
+the filesystem and PHP's tmp directory for this purpose. You can define your own
+interface (for example, if you'd like to use MySQL) by implementing the
+```alertLogger``` interface.
+
+If you don't use notification thresholds, this section doesn't apply to you.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -87,7 +87,7 @@ Checks
 sent. Optionally, you can define an alert threshold (useful for twitchy checks).
 If you define an alert threshold, you should also define an all-clear threshold.
 If you use thresholds, an alert logger will be used for alert persistence. More
-information on the logger interface is in a section below.
+information on the logger interface is in a section below::
 
     // Simple implementation:
     'checks' => [
@@ -97,16 +97,16 @@ information on the logger interface is in a section below.
 In this case, ``checkDB`` is a global function that throws an
 :class:`AlertinatorException` when some alerting threshold is passed.  When
 that happens, the alert will be sent out to members of the ``ops`` and ``devs``
-:ref:`groups`.
+:ref:`groups`::
 
     // Complex implementation, with alert thresholds:
     'checks' => [
-      'checkDB' => [
-         'groups' => ['ops'],
-         'alertAfter' => 5,
-         'clearAfter' => 2,
-         ],
-      ],
+        'checkDB' => [
+            'groups' => ['ops'],
+            'alertAfter' => 5,
+            'clearAfter' => 2,
+        ],
+    ],
 
 In this case, ``checkDB`` is still the check function, and when the alert
 exception is thrown, the alert will be sent to the ``ops`` group after the
@@ -125,7 +125,7 @@ Groups
 ^^^^^^
 
 Groups allow you to alert a number of people together without having to repeat
-their names.
+their names::
 
     'groups' => [
        'ops' => ['alice'],
@@ -193,7 +193,7 @@ Notification thresholds
 ^^^^^^^^
 
 Notification thresholds are definable on a per-check level. As in the example
-above, you define your thresholds like this:
+above, you define your thresholds like this::
 
     // With alert thresholds:
     'checks' => [
@@ -218,6 +218,6 @@ Alert persistence adaptor
 Using alert thresholds requires a persistence layer. Alertinator by default uses
 the filesystem and PHP's tmp directory for this purpose. You can define your own
 interface (for example, if you'd like to use MySQL) by implementing the
-```alertLogger``` interface.
+``alertLogger`` interface.
 
 If you don't use notification thresholds, this section doesn't apply to you.


### PR DESCRIPTION
A few of my assumptions based off #6:

> Customizable intervals: Notify me when the check fails, when it's been failing for at least 30min, 6hours...

Since checks are (ostensibly) already on a timer, I think it makes more sense to notify after _X_ failures/_Y_ successes.

> Be applied per (check-function, alert level) tuple

The way that `check()` is implemented, this is a problem. The alert level is based on which Exception class is used (e.g., `AlertinatorWarningException`), and in the case of success, the exception is never thrown. I have some ideas for implementing a better exception architecture (which would fit naturally into #3). As it stands, my code will alert on check-function only.

> Resetting counters for a given check after a successful run (Or X successful runs)

Implemented

> Storing any state locally on the file-system in whatever format makes sense.

Implemented as an Interface so someone could extend it to, say, mysql instead of the filesystem.

> If $shouldAlert is true, the caller of this function will format a nice message using the $firstAlertTimestamp; something like "$alertMessage -- sustained for 30 minutes".

Somewhat annoying -- the message is defined when the Exception is thrown and as you know there is no `$e->setMessage()` method. I did some dirty business to help, but the messaging methods will have to be refactored to get the level of robustness you're looking for.

This PR should be fully backwards-compatible. Unit tests are included and docs are updated.
