### PR TITLE
Alertinator: Prevent multiples of the same alert

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "twilio-php"]
 	path = twilio-php
-	url = https://github.com/twilio/twilio-php.git
+	url = git@github.com:twilio/twilio-php.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ git:
     submodules: false
 # See: https://gist.github.com/iedemam/9830045
 before_install:
-    - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
     - git submodule update --init --recursive
 language: php
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,5 @@ before_install:
     - git submodule update --init --recursive
 language: php
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
 script: phpunit AlertinatorTest.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
+  - 7.0
 script: phpunit AlertinatorTest.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_install:
     - git submodule update --init --recursive
 language: php
 php:
-  - 7.0
+  - 7.1
 script: phpunit AlertinatorTest.php

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -87,6 +87,10 @@ class Alertinator {
       }
    }
    
+   /**
+    * Threshold notification: determine if an all-clear alert should be sent,
+    * and if so, send it and reset the logger.
+   */
    private function notifyClear($check, $alertAfter, $clearAfter, $alerteeGroups) {
       $log = $this->logger->readAlerts($check);
       krsort($log);
@@ -123,7 +127,11 @@ class Alertinator {
          }
       }
    }
-      
+    
+   /**
+    * Threshold notification: determine if a failure alert should be sent, and
+    * if so, send it.
+   */  
    private function notifyFailure($check, $alertAfter, $alerteeGroups, $e) {
       $log = $this->logger->readAlerts($check);
       $fails = 0;
@@ -178,6 +186,9 @@ class Alertinator {
       }
    }
    
+   /**
+    * We sometimes need to modify the Exception's message for threshold alerts.
+   */
    private function prependExceptionMessage($e, $newMessage) {
       $oldMsg = $e->getMessage();
       $newMsg = $newMessage . $oldMsg;
@@ -261,6 +272,13 @@ interface alertLogger {
 
 class fileLogger implements alertLogger {
    
+   /**
+    * Write an alert to the logger.
+    *
+    * @param $name string  The key of the alert. Usually the name of the check fn.
+    * @param $status bool  0 = fail, 1 = success
+    * @param $ts int  Unix Timestamp of the event.
+   */
    public function writeAlert($name, $status, $ts = FALSE) {
       $ts = $ts ? $ts : time();
       $log = $this->readAlerts($name);
@@ -279,6 +297,9 @@ class fileLogger implements alertLogger {
       fclose($fp); 
    }
    
+   /**
+    * Return all alerts for a given key.
+   */
    public function readAlerts($name) {
       $log = array();
       if (file_exists($this->getLogFileName($name))) {
@@ -288,12 +309,18 @@ class fileLogger implements alertLogger {
       return $log;
    }
    
+   /**
+    * Reset all alerts for a given key.
+   */
    public function resetAlerts($name) {
       if(!unlink($this->getLogFileName($name))) {
          throw new Exception("Could not reset log file " . $this->getLogFileName($name) . "!");
       }
    }
    
+   /**
+    * Determine if there's at least one failure recorded.
+   */
    public function isInAlert($name) {
       return count($this->readAlerts($name));
    }

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -35,7 +35,7 @@ class Alertinator {
 
    protected $_twilio;
 
-   public function __construct($config, alertLogger $logger = NULL) {
+   public function __construct(array $config, alertLogger $logger = null) {
       $this->twilio = $config['twilio'];
       $this->checks = $config['checks'];
       $this->groups = $config['groups'];

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -142,7 +142,7 @@ class Alertinator {
       $reminderTriggered = $fails > $alertAfter
        && ($fails - $alertAfter) % $remindEvery == 0;
 
-      if ($fails && $fails >= $alertAfter && ($fails === $alertAfter || $reminderTriggered)) {
+      if ($fails === $alertAfter || $reminderTriggered) {
          $last = end($log);
          $newMsg = "Threshold of $alertAfter reached at "
           . date(DATE_RFC2822, $last['ts'])
@@ -314,6 +314,14 @@ class fileLogger implements alertLogger {
       return $log;
    }
    
+   /**
+    * Safely resets all alerts for a given key.
+   */
+   public function safelyResetAlerts($name) {
+      try {!unlink($this->getLogFileName($name)); }
+      catch (Exception $e) { }
+   }
+
    /**
     * Reset all alerts for a given key.
    */

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -57,7 +57,8 @@ class Alertinator {
          // determine if *After properties were defined.
          $alertAfter    = $properties['alertAfter'] ?? 0;
          $clearAfter    = $properties['clearAfter'] ?? 0;
-         $remindEvery   = $properties['remindEvery'] ?: $alertAfter ?: 1;
+         $remindEvery   = $properties['remindEvery'] ?? $alertAfter;
+         $remindEvery   = $remindEvery ?: 1;
          $alerteeGroups = $properties['groups'] ?? $properties;
          
          try {

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -40,7 +40,7 @@ class Alertinator {
       $this->checks = $config['checks'];
       $this->groups = $config['groups'];
       $this->alertees = $config['alertees'];
-      $this->logger = $logger ? $logger : new fileLogger();
+      $this->logger = $logger ?? new fileLogger();
       
    }
 
@@ -55,9 +55,9 @@ class Alertinator {
       foreach ($this->checks as $check => $properties) {
          // For compatibility with old-style (short style?) check declaration,
          // determine if *After properties were defined.
-         $alertAfter = !empty($properties['alertAfter']) ? $properties['alertAfter'] : 0;
-         $clearAfter = !empty($properties['clearAfter']) ? $properties['clearAfter'] : 0;
-         $alerteeGroups = !empty($properties['groups']) ? $properties['groups'] : $properties;
+         $alertAfter = $properties['alertAfter'] ?? 0;
+         $clearAfter = $properties['clearAfter'] ?? 0;
+         $alerteeGroups = $properties['groups'] ?? $properties;
          
          try {
             call_user_func($check);
@@ -280,7 +280,7 @@ class fileLogger implements alertLogger {
     * @param $ts int  Unix Timestamp of the event.
    */
    public function writeAlert($name, $status, $ts = FALSE) {
-      $ts = $ts ? $ts : time();
+      $ts = $ts ?: time();
       $log = $this->readAlerts($name);
       
       $alert = [
@@ -331,6 +331,6 @@ class fileLogger implements alertLogger {
    }
    
    private function getTmpDir() {
-      return ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir();
+      return ini_get('upload_tmp_dir') ?? sys_get_temp_dir();
    }
 }

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -136,15 +136,16 @@ class Alertinator {
          $fails++;
       }
 
-      $reminderTriggered = $fails > $alertAfter
-       && ($fails - $alertAfter) % $remindEvery == 0;
+      $atAlertThreshold = $fails === $alertAfter;
+      $pastAlertThreshold = $fails > $alertAfter;
+      $remindThisInterval = (($fails - $alertAfter) % $remindEvery) == 0;
+      $reminderNotification = $remindThisInterval && $pastAlertThreshold ?
+       " (reminding every {$remindEvery} fails)" : '';
 
-      if ($fails === $alertAfter || $reminderTriggered) {
+      if ($atAlertThreshold || ($pastAlertThreshold && $remindThisInterval)) {
          $last = end($log);
          $newMsg = "Threshold of $alertAfter reached at "
-          . date(DATE_RFC2822, $last['ts'])
-          . ($reminderTriggered ? " (reminding every {$remindEvery} fails)" : '')
-          . ": ";
+          . date(DATE_RFC2822, $last['ts']) . $reminderNotification . ": ";
          $e = $this->prependExceptionMessage($newMsg, $e);
          $this->alertGroups($e, $alerteeGroups);
       }
@@ -238,7 +239,7 @@ class Alertinator {
     * This function exists partly to ease mocking, and partly to abstract away
     * Twilio's deep object inheritance.
     */
-   protected function getTwilioSms(): Services_Twilio {
+   protected function getTwilioSms() {
       return $this->getTwilio()->account->messages;
    }
 
@@ -248,7 +249,7 @@ class Alertinator {
     * This function exists partly to ease mocking, and partly to abstract away
     * Twilio's deep object inheritance.
     */
-   protected function getTwilioCall(): Services_Twilio {
+   protected function getTwilioCall() {
       return $this->getTwilio()->account->calls;
    }
 

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -105,7 +105,7 @@ class Alertinator {
       if (count($log) >= $clearAfter) {
          $clears = 0;
          // Only notify a clear if the check passes > $clearAfter in a row.
-         foreach($log as $alert) {
+         foreach ($log as $alert) {
             if (!$alert['status']) {
                break;
             }
@@ -148,7 +148,7 @@ class Alertinator {
           . date(DATE_RFC2822, $last['ts'])
           . ($reminderTriggered ? " (reminding every {$remindEvery} fails)" : '')
           . ": ";
-         $e = $this->prependExceptionMessage($e, $newMsg);
+         $e = $this->prependExceptionMessage($newMsg, $e);
          $this->alertGroups($e, $alerteeGroups);
       }
    }
@@ -194,7 +194,7 @@ class Alertinator {
    /**
     * We sometimes need to modify the Exception's message for threshold alerts.
    */
-   private function prependExceptionMessage($e, $newMessage) {
+   private function prependExceptionMessage($newMessage, $e) {
       $oldMsg = $e->getMessage();
       $newMsg = $newMessage . $oldMsg;
       $eClass = get_class($e);

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -255,7 +255,7 @@ class Alertinator {
    /**
     * Return a configured :class:`Services_Twilio` object.
     */
-   protected function getTwilio(): Service_Twilio {
+   protected function getTwilio(): Services_Twilio {
       if (!$this->_twilio) {
          $this->_twilio = new Services_Twilio(
             $this->twilio['accountSid'],
@@ -269,7 +269,7 @@ interface alertLogger {
    public function writeAlert(string $name, bool $status, ?int $ts);
    public function readAlerts(string $name): array;
    public function resetAlerts(string $name);
-   public function isInAlert(string $name);
+   public function isInAlert(string $name): bool;
 }
 
 class fileLogger implements alertLogger {
@@ -330,7 +330,7 @@ class fileLogger implements alertLogger {
    /**
     * Determine if there's at least one failure recorded.
    */
-   public function isInAlert(string $name): int {
+   public function isInAlert(string $name): bool {
       return count($this->readAlerts($name));
    }
 

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -331,6 +331,6 @@ class fileLogger implements alertLogger {
    }
    
    private function getTmpDir() {
-      return ini_get('upload_tmp_dir') ?? sys_get_temp_dir();
+      return ini_get('upload_tmp_dir') ?: sys_get_temp_dir();
    }
 }

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -95,7 +95,7 @@ class Alertinator {
       // We only get here if there was at least 1 failure, but 1 failure may not
       // exceed the alertAfter threshold. If the check succeeds without
       // reaching the alert threshold, reset the log silently.
-      // TODO: this will break terribly for bouncing errors, e.g. pass-> fail->
+      // Note: this will break terribly for bouncing errors, e.g. pass-> fail->
       //       pass-> fail-> pass-> fail. Account for this.
       if (count($log) < $alertAfter) {
          $this->logger->resetAlerts($check);

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -139,7 +139,8 @@ class Alertinator {
          }
       }
 
-      $reminderTriggered = $fails % ($remindEvery + $alertAfter) == 0;
+      $reminderTriggered = $fails > $alertAfter
+       && ($fails - $alertAfter) % $remindEvery == 0;
 
       if ($fails && $fails >= $alertAfter && ($fails === $alertAfter || $reminderTriggered)) {
          $last = end($log);

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -35,11 +35,13 @@ class Alertinator {
 
    protected $_twilio;
 
-   public function __construct($config) {
+   public function __construct($config, alertLogger $logger = NULL) {
       $this->twilio = $config['twilio'];
       $this->checks = $config['checks'];
       $this->groups = $config['groups'];
       $this->alertees = $config['alertees'];
+      $this->logger = $logger ? $logger : new fileLogger();
+      
    }
 
    /**
@@ -50,11 +52,27 @@ class Alertinator {
     *                    checks.
     */
    public function check() {
-      foreach ($this->checks as $check => $alerteeGroups) {
+      foreach ($this->checks as $check => $properties) {
+         // For compatibility with old-style (short style?) check declaration,
+         // determine if *After properties were defined.
+         $alertAfter = !empty($properties['alertAfter']) ? $properties['alertAfter'] : 0;
+         $clearAfter = !empty($properties['clearAfter']) ? $properties['clearAfter'] : 0;
+         $alerteeGroups = !empty($properties['groups']) ? $properties['groups'] : $properties;
+         
          try {
             call_user_func($check);
+            if ($clearAfter && $this->logger->isInAlert($check)) {
+               $this->logger->writeAlert($check, 1, time());
+               $this->notifyClear($check, $alertAfter, $clearAfter, $alerteeGroups);
+            }
          } catch (AlertinatorException $e) {
-            $this->alertGroups($e, $alerteeGroups);
+            if ($alertAfter) {
+               $this->logger->writeAlert($check, 0, time());
+               $this->notifyFailure($check, $alertAfter, $alerteeGroups, $e);
+            }
+            else {
+               $this->alertGroups($e, $alerteeGroups);
+            }
          } catch (Exception $e) {
             // If there's an error in your check functions, you damn better
             // know about it.
@@ -68,7 +86,53 @@ class Alertinator {
          }
       }
    }
-
+   
+   private function notifyClear($check, $alertAfter, $clearAfter, $alerteeGroups) {
+      $log = $this->logger->readAlerts($check);
+      krsort($log);
+      
+      // We only get here if there was at least 1 failure, but 1 failure may not
+      // exceed the alertAfter threshold. If the check succeeds without
+      // reaching the alert threshold, reset the log silently.
+      // TODO: this will break terribly for bouncing errors, e.g. pass-> fail->
+      //       pass-> fail-> pass-> fail. Account for this.
+      if (count($log) < $alertAfter) {
+         $this->logger->resetAlerts($check);
+         return;
+      }
+      
+      if (count($log) >= $clearAfter) {
+         $clears = 0;
+         // Only notify a clear if the check passes > $clearAfter in a row.
+         foreach($log as $ts => $alert) {
+            if (!$alert['status']) {
+               break;
+            }
+            $clears++;
+         }
+         if ($clears >= $clearAfter) {
+            $message = "The alert '$check' was cleared at " . date(DATE_RFC2822, key(reset($log))) . ".";
+            $this->alertGroups($message, $alerteeGroups);
+            $this->resetLog($check);
+         }
+      }
+   }
+      
+   private function notifyFailure($check, $alertAfter, $alerteeGroups, $e) {
+      $log = $this->logger->readAlerts($check);
+      krsort($log);
+      $fails = 0;
+      foreach ($log as $ts => $alert) {
+         if (!$alert['status']) {
+            $fails++;
+         }
+      }
+      if ($fails >= $alertAfter) {
+         $e = "Threshold of $alertAfter reached at " . date(DATE_RFC2822, key(reset($log))) . ": " . $e;
+         $this->alertGroups($e, $alerteeGroups);  
+      }
+   }
+   
    protected function alertGroups($exception, $alerteeGroups) {
       $alertees = $this->extractAlertees($alerteeGroups);
       foreach ($alertees as $alertee) {
@@ -174,3 +238,58 @@ class Alertinator {
    }
 }
 
+interface alertLogger {
+   public function writeAlert($name, $status, $ts);
+   public function readAlerts($name);
+   public function resetAlerts($name);
+   public function isInAlert($name);
+}
+
+class fileLogger implements alertLogger {
+   
+   public function writeAlert($name, $status, $ts = FALSE) {
+      $ts = $ts ? $ts : time();
+      $log = $this->readAlerts($name);
+      
+      $alert = [$ts => [
+                          'status' => $status,
+                          'check' => $name,
+                          ],
+              ];
+      
+      $log += $alert;
+      if (!$fp = fopen($this->getLogFileName($name), 'w')) {
+         throw new Exception("Could not open log file " . $this->getLogFileName($name) . " for writing.");
+      }
+      fwrite($fp, json_encode($log));
+      fclose($fp); 
+   }
+   
+   public function readAlerts($name) {
+      $log = array();
+      if (file_exists($this->getLogFileName($name))) {
+         $prevLog = file_get_contents($this->getLogFileName($name));
+         $log = json_decode($prevLog, true);  
+      }
+      return $log;
+   }
+   
+   public function resetAlerts($name) {
+      if(!unlink($this->getLogFileName($name))) {
+         throw new Exception("Could not reset log file " . $this->getLogFileName($name) . "!");
+      }
+   }
+   
+   public function isInAlert($name) {
+      return count($this->readAlerts($name));
+   }
+   
+   private function getLogFileName($name) {
+      $file = strtolower(mb_ereg_replace("([^\w\s\d\-_~,;:\[\]\(\).])", '', $name));
+      return $this->getTmpDir() . '/' . $file . '.log';
+   }
+   
+   private function getTmpDir() {
+      return ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir();
+   }
+}

--- a/AlertinatorTest.php
+++ b/AlertinatorTest.php
@@ -159,6 +159,59 @@ class AlertinatorTest extends PHPUnit_Framework_TestCase {
          [new AlertinatorWarningException('foobaz'), $alertees]
       );
    }
+   
+   public function test_error_thresholds() {
+      $alertinator = new AlertinatorMocker([
+         'twilio' => ['fromNumber' => '1234567890'],
+         'checks' => [
+            'AlertinatorTest::thresholdChecker' => [
+               'groups' => ['default'],
+               'alertAfter' => 5,
+               'clearAfter' => 2,
+               ],
+            ],
+         'groups' => ['default' => ['alice']],
+         'alertees' => [
+            'alice' => ['email' => ['alice@example.com', Alertinator::CRITICAL]],
+         ],
+      ]);
+      $this->expectOutputString('');
+      $alertinator->check();
+      
+      //$this->expectOutputString('POOP');
+      //$alertinator->check();
+      
+      
+      //$this->expectOutputEquals(
+      //   "",
+      //   [new AlertinatorWarningException('foobaz')]
+      //);
+      
+      //$this->expectOutputEquals(
+      //   "",
+      //   [$alertinator, 'check']
+      //);
+      //
+      //$this->expectOutputEquals(
+      //   "",
+      //   [$alertinator, 'check']
+      //);
+      //
+      //$this->expectOutputEquals(
+      //   "",
+      //   [$alertinator, 'check']
+      //);
+      //
+      //$this->expectOutputEquals(
+      //   "Sending message to alice@example.com via email.\n",
+      //   [$alertinator, 'check']
+      //);
+      //
+      //$this->expectOutputEquals(
+      //   "Sending message to alice@example.com via email.\n",
+      //   [$alertinator, 'check']
+      //);
+   }
 
    /**
     * @expectedException         PHPUnit_Framework_Error_Notice
@@ -180,6 +233,12 @@ class AlertinatorTest extends PHPUnit_Framework_TestCase {
          "Sending message $message to alice@example.com via email.\n",
          [$alertinator, 'check']
       );
+   }
+   
+   public static function thresholdChecker() {
+      //static $i = 1;
+      throw new AlertinatorCriticalException('foobaz');
+      
    }
 
    /**

--- a/AlertinatorTest.php
+++ b/AlertinatorTest.php
@@ -46,7 +46,7 @@ class TwilioMocker {
    }
 }
 
-class AlertinatorTest extends PHPUnit_Framework_TestCase {
+class AlertinatorTest extends PHPUnit\Framework\TestCase {
    protected function setUp() {
       date_default_timezone_set("America/Los_Angeles");
       // Create an Alertinator with just enough config to construct.
@@ -286,7 +286,7 @@ class AlertinatorTest extends PHPUnit_Framework_TestCase {
    }
 
    /**
-    * @expectedException         PHPUnit_Framework_Error_Notice
+    * @expectedException         PHPUnit\Framework\Error\Notice
     * @expectedExceptionMessage  Use of undefined constant sdf - assumed 'sdf'
     */
    public function test_check_errors() {

--- a/AlertinatorTest.php
+++ b/AlertinatorTest.php
@@ -10,23 +10,23 @@ require 'Alertinator.php';
  * external-service-using in Alertinator.
  */
 class AlertinatorMocker extends Alertinator {
-   public function extractAlertees($alerteeGroups) {
+   public function extractAlertees(iterable $alerteeGroups): array {
       return parent::extractAlertees($alerteeGroups);
    }
 
-   public function alert($exception, $alertee) {
+   public function alert(AlertinatorException $exception, iterable $alertee) {
       return parent::alert($exception, $alertee);
    }
 
-   public function email($address, $message) {
+   public function email(string $address, string $message) {
       echo "Sending message $message to $address via email.\n";
    }
 
-   public function getTwilioSms() {
+   public function getTwilioSms(): Services_Twilio {
       return new TwilioMocker();
    }
 
-   public function getTwilioCall() {
+   public function getTwilioCall(): Services_Twilio {
       return new TwilioMocker();
    }
 }
@@ -37,7 +37,9 @@ class AlertinatorMocker extends Alertinator {
  * can't call it like a method, and I'm not going to alter the source to make
  * the tests slightly better.
  */
-class TwilioMocker {
+class TwilioMocker extends Services_Twilio {
+   function __construct() { }
+
    public function sendMessage($fromNumber, $toNumber, $message) {
       echo "Sending message $message to $toNumber via sms.\n";
    }
@@ -275,8 +277,7 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
       // TODO: As you can see, this state is (maybe?) not handled well.
       // @see Alertinator::notifyClear()
       for ($i = 0; $i < 19; $i++) {
-         $this->expectOutputString('');
-         $alertinator->check();   
+         $this->expectOutputString('', [$alertinator, 'check']);
       }
    }
 
@@ -401,7 +402,6 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
       if ($counter++ < 4) {
          throw new AlertinatorCriticalException('Fail Four Times Test');
       }
-      return;
    }
 
    /**
@@ -414,7 +414,6 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
       if ($counter++ < 5) {
          throw new AlertinatorCriticalException('Fail Five Times Test');
       }
-      return;
    }
    
    /**
@@ -433,7 +432,6 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
       if ($counter++ < 24 && !$passing) {
          throw new AlertinatorCriticalException('Fail 3Bouncer');
       }
-      return;
    }
 
    /**
@@ -441,10 +439,10 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
    */
    public static function failBouncer() {
       static $counter = 0;
+
       if (!($counter % 2) && $counter++ < 25) {
          throw new AlertinatorCriticalException('Fail Bouncer');
       }
-      return;
    }
 
    /**

--- a/AlertinatorTest.php
+++ b/AlertinatorTest.php
@@ -22,11 +22,11 @@ class AlertinatorMocker extends Alertinator {
       echo "Sending message $message to $address via email.\n";
    }
 
-   public function getTwilioSms(): Services_Twilio {
+   public function getTwilioSms() {
       return new TwilioMocker();
    }
 
-   public function getTwilioCall(): Services_Twilio {
+   public function getTwilioCall() {
       return new TwilioMocker();
    }
 }

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ reasonable subset of features at a fraction of the cost.
     ];
     (new Alertinator($config))->check();
 
+For more advanced usage, including using alert thresholds, see the [user guide](https://github.com/ifixit/alertinator/blob/master/docs/user_guide.rst).
+
 ## License
 
 Alertinator is available under the LGPL 3.0, which means that while any code

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -50,14 +50,9 @@ money (the Twilio integration) - it's easy to swap it out for an alternative,
 or even ignore it altogether.
 
 An :class:`Alertinator` is constructed with one argument, a nested associative
-array containing all the information about your alerting system.  Due to PHP's
-lack of support for `splatting`_ parameters, the single-array method was chosen
-to provide the greatest calling flexibility - you can construct it piece by
-piece or all in one go.
+array containing all the information about your alerting system:
 
 ``$config`` consists of four parts:
-
-.. _splatting: https://endofline.wordpress.com/2011/01/21/the-strange-ruby-splat/
 
 Twilio
 ^^^^^^
@@ -89,8 +84,12 @@ Checks
 ^^^^^^
 
 ``checks`` determines which alerts are checked and to whom notifications are
-sent.
+sent. Optionally, you can define an alert threshold (useful for twitchy checks).
+If you define an alert threshold, you should also define an all-clear threshold.
+If you use thresholds, an alert logger will be used for alert persistence. More
+information on the logger interface is in a section below.
 
+    // Simple implementation:
     'checks' => [
        'checkDB' => ['ops', 'devs'],
     ],
@@ -99,6 +98,20 @@ In this case, ``checkDB`` is a global function that throws an
 :class:`AlertinatorException` when some alerting threshold is passed.  When
 that happens, the alert will be sent out to members of the ``ops`` and ``devs``
 :ref:`groups`.
+
+    // Complex implementation, with alert thresholds:
+    'checks' => [
+      'checkDB' => [
+         'groups' => ['ops'],
+         'alertAfter' => 5,
+         'clearAfter' => 2,
+         ],
+      ],
+
+In this case, ``checkDB`` is still the check function, and when the alert
+exception is thrown, the alert will be sent to the ``ops`` group after the
+``afterAlert`` threshold is met. Also, once the check passes ``clearAfter``
+times in a row, an all-clear alert will be sent.
 
 It's not necessarily a good idea to use global function for your alerts.
 Correspondingly, alert names can be any PHP `callable`_, e.g.
@@ -166,9 +179,8 @@ this::
 We've extended :class:`Alertinator` to add this method::
 
     class AlertChecker extends Alertinator {
-       /**
-        * Send $message to $recipient via DevChat.
-        */
+       
+       // Send $message to $recipient via DevChat. 
        protected function devChatAnnounce($recipient, $message) {
           // Code here.
        }
@@ -177,3 +189,35 @@ We've extended :class:`Alertinator` to add this method::
 And we construct and call ``alert()`` on our ``AlertChecker`` class instead of
 :class:`Alertinator` directly.
 
+Notification thresholds
+^^^^^^^^
+
+Notification thresholds are definable on a per-check level. As in the example
+above, you define your thresholds like this:
+
+    // With alert thresholds:
+    'checks' => [
+      'checkDB' => [
+         'groups' => ['ops'],
+         'alertAfter' => 5,
+         'clearAfter' => 2,
+         ],
+      ],
+      
+``alertAfter``: send alerts after this many sequential failures. This is counted
+in a row: any successes on the same check before the alert threshold is met will
+reset the alert counter silently.
+
+``clearAfter``: send an all-clear message after this many sequential successes.
+Note: the all-clear message will send at the ``AlertinatorCriticalException``
+level, no matter what level the initial exception was.
+
+Alert persistence adaptor
+^^^^^^^^
+
+Using alert thresholds requires a persistence layer. Alertinator by default uses
+the filesystem and PHP's tmp directory for this purpose. You can define your own
+interface (for example, if you'd like to use MySQL) by implementing the
+```alertLogger``` interface.
+
+If you don't use notification thresholds, this section doesn't apply to you.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -87,7 +87,7 @@ Checks
 sent. Optionally, you can define an alert threshold (useful for twitchy checks).
 If you define an alert threshold, you should also define an all-clear threshold.
 If you use thresholds, an alert logger will be used for alert persistence. More
-information on the logger interface is in a section below.
+information on the logger interface is in a section below::
 
     // Simple implementation:
     'checks' => [
@@ -97,16 +97,16 @@ information on the logger interface is in a section below.
 In this case, ``checkDB`` is a global function that throws an
 :class:`AlertinatorException` when some alerting threshold is passed.  When
 that happens, the alert will be sent out to members of the ``ops`` and ``devs``
-:ref:`groups`.
+:ref:`groups`::
 
     // Complex implementation, with alert thresholds:
     'checks' => [
-      'checkDB' => [
-         'groups' => ['ops'],
-         'alertAfter' => 5,
-         'clearAfter' => 2,
-         ],
-      ],
+        'checkDB' => [
+            'groups' => ['ops'],
+            'alertAfter' => 5,
+            'clearAfter' => 2,
+        ],
+    ],
 
 In this case, ``checkDB`` is still the check function, and when the alert
 exception is thrown, the alert will be sent to the ``ops`` group after the
@@ -125,7 +125,7 @@ Groups
 ^^^^^^
 
 Groups allow you to alert a number of people together without having to repeat
-their names.
+their names::
 
     'groups' => [
        'ops' => ['alice'],
@@ -193,7 +193,7 @@ Notification thresholds
 ^^^^^^^^
 
 Notification thresholds are definable on a per-check level. As in the example
-above, you define your thresholds like this:
+above, you define your thresholds like this::
 
     // With alert thresholds:
     'checks' => [
@@ -218,6 +218,6 @@ Alert persistence adaptor
 Using alert thresholds requires a persistence layer. Alertinator by default uses
 the filesystem and PHP's tmp directory for this purpose. You can define your own
 interface (for example, if you'd like to use MySQL) by implementing the
-```alertLogger``` interface.
+``alertLogger`` interface.
 
 If you don't use notification thresholds, this section doesn't apply to you.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -103,15 +103,18 @@ that happens, the alert will be sent out to members of the ``ops`` and ``devs``
     'checks' => [
         'checkDB' => [
             'groups' => ['ops'],
-            'alertAfter' => 5,
-            'clearAfter' => 2,
+            'alertAfter'  => 5,
+            'clearAfter'  => 2,
+            'remindEvery' => 1,
         ],
     ],
 
 In this case, ``checkDB`` is still the check function, and when the alert
 exception is thrown, the alert will be sent to the ``ops`` group after the
 ``afterAlert`` threshold is met. Also, once the check passes ``clearAfter``
-times in a row, an all-clear alert will be sent.
+times in a row, an all-clear alert will be sent. Finally, the ``remindEvery``
+threshold limits reminders to only every X errors after the first alert is
+sent.
 
 It's not necessarily a good idea to use global function for your alerts.
 Correspondingly, alert names can be any PHP `callable`_, e.g.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -111,10 +111,9 @@ that happens, the alert will be sent out to members of the ``ops`` and ``devs``
 
 In this case, ``checkDB`` is still the check function, and when the alert
 exception is thrown, the alert will be sent to the ``ops`` group after the
-``afterAlert`` threshold is met. Also, once the check passes ``clearAfter``
-times in a row, an all-clear alert will be sent. Finally, the ``remindEvery``
-threshold limits reminders to only every X errors after the first alert is
-sent.
+``alertAfter`` threshold is met. Also, once the check passes ``clearAfter``
+times in a row, an all-clear alert will be sent. Finally, reminder alerts are
+limited to only every ``remindEvery`` errors after the first alert is sent.
 
 It's not necessarily a good idea to use global functions for your alerts.
 Correspondingly, alert names can be any PHP `callable`_, e.g.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -204,6 +204,7 @@ above, you define your thresholds like this::
          'groups' => ['ops'],
          'alertAfter' => 5,
          'clearAfter' => 2,
+         'remindEvery' => 1,
          ],
       ],
       
@@ -214,6 +215,9 @@ reset the alert counter silently.
 ``clearAfter``: send an all-clear message after this many sequential successes.
 Note: the all-clear message will send at the ``AlertinatorCriticalException``
 level, no matter what level the initial exception was.
+
+``remindEvery``: this threshold limits reminders to only every X errors after
+the first alert is sent.
 
 Alert persistence adaptor
 ^^^^^^^^


### PR DESCRIPTION
From @entendu 
--
_(previous PR was from `entendu:master` so I am making a new PR as a separate `ifixit/alertinator` branch)_
```
A few of my assumptions based off #6:

> Customizable intervals: Notify me when the check fails, when it's been failing for at least 30min, 6hours...

Since checks are (ostensibly) already on a timer, I think it makes more sense to notify after _X_ failures/_Y_ successes.

> Be applied per (check-function, alert level) tuple

The way that `check()` is implemented, this is a problem. The alert level is based on which Exception class is used (e.g., `AlertinatorWarningException`), and in the case of success, the exception is never thrown. I have some ideas for implementing a better exception architecture (which would fit naturally into #3). As it stands, my code will alert on check-function only.

> Resetting counters for a given check after a successful run (Or X successful runs)

Implemented

> Storing any state locally on the file-system in whatever format makes sense.

Implemented as an Interface so someone could extend it to, say, mysql instead of the filesystem.

> If $shouldAlert is true, the caller of this function will format a nice message using the $firstAlertTimestamp; something like "$alertMessage -- sustained for 30 minutes".

Somewhat annoying -- the message is defined when the Exception is thrown and as you know there is no `$e->setMessage()` method. I did some dirty business to help, but the messaging methods will have to be refactored to get the level of robustness you're looking for.

This PR should be fully backwards-compatible. Unit tests are included and docs are updated.
```

CR
--
It looks bad, but at least 20% of the changes are documentation-only. Go commit by commit, and notice any code differences where the authors change.

QA
--
- [ ] Check for an alert after X failures
  - [ ] Check that a fail clears the running count of successes
- [ ] Check for an all-clear message after Y successes
  - [ ] Check that all-clear clears the running count of fails
- [ ] Check for an alert after every `$fails % $remindEvery == 0`
  - [ ] Check that alert reminder/spam prevention resets at Y number of successes
- [ ] Test backwards compatibility
  - Could be done by loading this branch as a git module on cominor and triggering an alert/all-clear cycle
  - Could also be done by loading this branch and using a `$config` from prior versions

*Run this `AlertinatorQA.php` as a test driver for a local Alertinator clone. PM me for necessary credentials.*
```php
<?php

require 'Alertinator.php';


$tester = (new AlertinatorQA());
$tester->check();

$GLOBALS['pf'] = true;

function testChecks() {
   $pf = $GLOBALS['pf'] ? 'passes' : 'fails';
   echo("Test " . $pf . "\n");
   if($GLOBALS['pf'])
      return;
   else
      throw new AlertinatorNoticeException("{$pf}");
}


class AlertinatorQA {
   public function __construct() {
      $myNumber = readline("Enter 10 digit phone number with no spaces, dashes or parens: ");
      $email = readline("Enter email: ");
      $sid = readline("Enter sid: ");
      $token = readline("Enter token: ");
      $alertAfter = intval(readline("alert after X fails: "));
      $clearAfter = intval(readline("clear after X passes: "));
      $remindEvery = intval(readline("remind every X failures: "));
      $config = [
         'twilio' => [
            'fromNumber' => '+18058745977',
            'accountSid' => '$sid',
            'authToken' => '$token',
         ],
         'checks' => [
            'testChecks' => [
                'groups' => ['default'],
                'alertAfter' => $alertAfter,
                'clearAfter' => $clearAfter,
                'remindEvery' => $remindEvery,
            ],
         ],
         'groups' => [
            'default' => [
               'me',
            ],
         ],
         'alertees' => [
            'me' => [
               'email' => [$email, Alertinator::NOTICE | Alertinator::WARNING],
               'sms' => [$myNumber, Alertinator::WARNING | Alertinator::CRITICAL],
               'call' => [$myNumber, /*Alertinator::CRITICAL*/ 0],
            ],
         ],
      ];

      $this->alertinator = new Alertinator($config);
   }

   public function check() {
      while(true) {
         $GLOBALS['pf'] = readline("p/f (pass/fail next test?): ") == "p";
         if($GLOBALS['pf'])
            echo "Passing...";
         else
            echo "Failing...";
         $this->alertinator->check($GLOBALS['pf']);
      }
   }
}
```

Closes #6 
Closes on submodule update https://github.com/iFixit/ifixit/issues/22839