### PR TITLE
Docs: fix typos

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -100,7 +100,7 @@ In this case, ``checkDB`` is a global function that throws an
 that happens, the alert will be sent out to members of the ``ops`` and ``devs``
 :ref:`groups`.
 
-It's not necessarily a good idea to use global function for your alerts.
+It's not necessarily a good idea to use global functions for your alerts.
 Correspondingly, alert names can be any PHP `callable`_, e.g.
 ``AlertChecker::checkDB``.
 
@@ -132,7 +132,7 @@ If an alert is triggered but no one's around to hear it, your boss will let you
 know the next morning whether the system broke (hint: the answer is always
 yes).
 
-``alertees`` comprise the most complex of the data structures in ``$config``.
+``alertees`` comprises the most complex of the data structures in ``$config``.
 Here's an example with two people::
 
     'alertees' => [

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -62,7 +62,7 @@ piece or all in one go.
 Twilio
 ^^^^^^
 
-The ``twilio`` key should refer to an associate array with three entries::
+The ``twilio`` key should refer to an associative array with three entries::
 
     'twilio' => [
        'fromNumber' => '+12345678901',


### PR DESCRIPTION
Was reading through #11, and came across a few things to fix in the docs.