### PR TITLE
Set Correct Gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "twilio-php"]
 	path = twilio-php
-	url = https://github.com/twilio/twilio-php
+	url = git@github.com:twilio/twilio-php.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ git:
     submodules: false
 # See: https://gist.github.com/iedemam/9830045
 before_install:
+    - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
     - git submodule update --init --recursive
 language: php
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+# Handle git submodules yourself
+git:
+    submodules: false
+# See: https://gist.github.com/iedemam/9830045
+before_install:
+    - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+    - git submodule update --init --recursive
 language: php
 php:
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,3 @@
-# Handle git submodules yourself
-git:
-    submodules: false
-# See: https://gist.github.com/iedemam/9830045
-before_install:
-    - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-    - git submodule update --init --recursive
 language: php
 php:
   - 7.1


### PR DESCRIPTION
Unfortunately we have to remain hacky in this PR, as the `git@github` method of fetching Twilio fails Travis CI, and using `https` in a submodule URL fails Cimpler CI. This reverts an earlier change that broke integration into iFixit/iFixit.

qa_req 0 (tests pass, this is a test-only pull)