### PR TITLE
Update twilio php to 6.6.0

### DIFF
--- a/Alertinator.php
+++ b/Alertinator.php
@@ -235,11 +235,11 @@ class Alertinator {
    protected function call(string $number, string $message): void {
       $twiml = new VoiceResponse();
       $twiml->say($message);
-      $messageUrl = 'http://twimlets.com/echo?Twiml=' . urlencode($twiml);
+      $twiml->hangup();
 
       $number = '+1' . $number;
       $this->getTwilioCall()->create(
-       $number, $this->twilio['fromNumber'], ['url' => $messageUrl]);
+       $number, $this->twilio['fromNumber'], ['Twiml' => $twiml]);
    }
 
    /**

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -1,6 +1,9 @@
 <?php
 
-require 'twilio-php/Services/Twilio.php';
+require 'twilio-php/src/Twilio/autoload.php';
+
+use Twilio\Rest\Client;
+use Twilio\TwiML\VoiceResponse;
 
 /**
  * The base exception class Alertinator uses.
@@ -226,7 +229,7 @@ class Alertinator {
     * ``$message``.
     */
    protected function call(string $number, string $message) {
-      $twiml = new Services_Twilio_Twiml();
+      $twiml = new VoiceResponse();
       $twiml->say($message);
       $messageUrl = 'http://twimlets.com/echo?Twiml=' . urlencode($twiml);
 
@@ -242,7 +245,7 @@ class Alertinator {
     * Twilio's deep object inheritance.
     */
    protected function getTwilioSms() {
-      return $this->getTwilio()->account->messages;
+      return $this->getTwilio()->messages;
    }
 
    /**
@@ -252,15 +255,15 @@ class Alertinator {
     * Twilio's deep object inheritance.
     */
    protected function getTwilioCall() {
-      return $this->getTwilio()->account->calls;
+      return $this->getTwilio()->calls;
    }
 
    /**
-    * Return a configured :class:`Services_Twilio` object.
+    * Return a configured :class:`Client` object.
     */
-   protected function getTwilio(): Services_Twilio {
+   protected function getTwilio(): Client {
       if (!$this->_twilio) {
-         $this->_twilio = new Services_Twilio(
+         $this->_twilio = new Client(
             $this->twilio['accountSid'],
             $this->twilio['authToken']);
       }

--- a/Alertinator.php
+++ b/Alertinator.php
@@ -4,6 +4,8 @@ require 'twilio-php/src/Twilio/autoload.php';
 
 use Twilio\Rest\Client;
 use Twilio\TwiML\VoiceResponse;
+use Twilio\Rest\Api\V2010\Account\MessageList;
+use Twilio\Rest\Api\V2010\Account\CallList;
 
 /**
  * The base exception class Alertinator uses.
@@ -185,7 +187,7 @@ class Alertinator {
     * :param array $alertee: An array describing an alertee in the format
     *                        of ``$this->alertees``.
     */
-   protected function alert(AlertinatorException $exception, iterable $alertee) {
+   protected function alert(AlertinatorException $exception, iterable $alertee): void {
       foreach (array_keys($alertee) as $contactMethod) {
          list($destination, $alertingLevel) = $alertee[$contactMethod];
          if ($exception::bitmask & $alertingLevel) {
@@ -207,7 +209,7 @@ class Alertinator {
    /**
     * Send an email to ``$address`` with ``$message`` as the body.
     */
-   protected function email(string $address, string $message) {
+   protected function email(string $address, string $message): void {
       if (!mail($address, $this->emailSubject, $message)) {
          throw new Exception("Sending email to $address failed.");
       }
@@ -216,26 +218,28 @@ class Alertinator {
    /**
     * Send an SMS of ``$message`` through Twilio to ``$number``.
     */
-   protected function sms(string $number, string $message) {
+   protected function sms(string $number, string $message): void {
       // For reasons unknown, SMS doesn't seem to need the '+1' prepended like
       // phone calls do.  I probably just don't understand telephones.
       //$number = '+1' . $number;
-      $this->getTwilioSms()->sendMessage(
-       $this->twilio['fromNumber'], $number, $message);
+      $this->getTwilioSms()->create($number, [
+         'from' => $this->twilio['fromNumber'],
+         'body' => $message,
+      ]);
    }
 
    /**
     * Make a phone call through Twilio to ``$number``, with text-to-speech of
     * ``$message``.
     */
-   protected function call(string $number, string $message) {
+   protected function call(string $number, string $message): void {
       $twiml = new VoiceResponse();
       $twiml->say($message);
       $messageUrl = 'http://twimlets.com/echo?Twiml=' . urlencode($twiml);
 
       $number = '+1' . $number;
       $this->getTwilioCall()->create(
-       $this->twilio['fromNumber'], $number, $messageUrl);
+       $number, $this->twilio['fromNumber'], ['url' => $messageUrl]);
    }
 
    /**
@@ -244,7 +248,7 @@ class Alertinator {
     * This function exists partly to ease mocking, and partly to abstract away
     * Twilio's deep object inheritance.
     */
-   protected function getTwilioSms() {
+   protected function getTwilioSms(): MessageList {
       return $this->getTwilio()->messages;
    }
 
@@ -254,7 +258,7 @@ class Alertinator {
     * This function exists partly to ease mocking, and partly to abstract away
     * Twilio's deep object inheritance.
     */
-   protected function getTwilioCall() {
+   protected function getTwilioCall(): CallList {
       return $this->getTwilio()->calls;
    }
 

--- a/AlertinatorTest.php
+++ b/AlertinatorTest.php
@@ -39,14 +39,14 @@ class AlertinatorMocker extends Alertinator {
 }
 
 class MockMessage extends MessageInstance {
-   public function __construct() { }
+   public function __construct() {}
 }
 class MockCall extends CallInstance {
-   public function __construct() { }
+   public function __construct() {}
 }
 
 class TwilioMessagesMocker extends MessageList {
-   public function __construct() { }
+   public function __construct() {}
 
    public function create(string $toNumber, array $options = []): MessageInstance {
       $from = $options['from'];
@@ -57,11 +57,11 @@ class TwilioMessagesMocker extends MessageList {
 }
 
 class TwilioCallsMocker extends CallList {
-   public function __construct() { }
+   public function __construct() {}
 
    public function create(string $to, string $from, array $options = []): CallInstance {
-      $messageUrl = $options['url'];
-      echo "Sending message from $messageUrl to $to via call.\n";
+      $twiml = $options['Twiml'];
+      echo "Sending message with TwiML $twiml to $to via call.\n";
       return new MockCall();
    }
 }
@@ -166,16 +166,14 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
          'sms' => ['1234567890', Alertinator::WARNING],
          'call' => ['1234567890', Alertinator::WARNING],
       ];
-      // Because Twilio doesn't allow you to just send along a message
-      // directly, you have to create a url that returns the message.
       $twiml = new VoiceResponse();
       $twiml->say('foobaz');
-      $url = 'http://twimlets.com/echo?Twiml=' . urlencode($twiml);
+      $twiml->hangup();
 
       $this->expectOutputEquals(
          "Sending message foobaz to foo@example.com via email.\n"
          . "Sending message foobaz to 1234567890 via sms.\n"
-         . "Sending message from $url to +11234567890 via call.\n",
+         . "Sending message with TwiML $twiml to +11234567890 via call.\n",
          [$this->alertinator, 'alert'],
          [new AlertinatorWarningException('foobaz'), $alertees]
       );

--- a/AlertinatorTest.php
+++ b/AlertinatorTest.php
@@ -178,7 +178,7 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
          [new AlertinatorWarningException('foobaz'), $alertees]
       );
    }
-   
+
    /**
     * Test the default storage interface.
    */
@@ -186,25 +186,25 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
       $fl = new fileLogger();
       // Nothing logged, this should be empty:
       $this->assertEmpty($fl->isInAlert('foofail'));
-      
+
       // Write a failure, see if it was written:
       $fl->writeAlert('foofail', 0);
       $log = $fl->readAlerts('foofail');
       $this->assertNotEquals('barfail', $log[0]['check']);
       $this->assertEquals('foofail', $log[0]['check']);
       $this->assertEquals(0, $log[0]['status']);
-      
+
       // Write a success, see if it was written:
       $fl->writeAlert('foofail', 1);
       $log = $fl->readAlerts('foofail');
       $this->assertNotEquals('barfail', $log[1]['check']);
       $this->assertEquals('foofail', $log[1]['check']);
       $this->assertEquals(1, $log[1]['status']);
-      
+
       // Reset alerts, confirm that the log is empty:
       $fl->resetAlerts('foofail');
       $this->assertEmpty($fl->isInAlert('foofail'));
-      
+
       // Since order is important for determining alert clears, see if slamming
       // the interface breaks things.
       $test_values = array();
@@ -218,12 +218,12 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
       foreach ($test_values as $k => $v) {
          $this->assertEquals($v, $log[$k]['status']);
       }
-      
+
       // Reset alerts, confirm again that the log is empty:
       $fl->resetAlerts('megacount');
       $this->assertEmpty($fl->isInAlert('megacount'));
    }
-   
+
    /**
     * Test the threshold functionality.
    */
@@ -243,35 +243,35 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
          ],
       ]);
       $alertinator->logger->safelyResetAlerts(key($alertinator->checks));
-      
+
       // The first 4 alerts should do nothing...
       $this->expectOutputEquals('', [$alertinator, 'check']);
       $this->expectOutputEquals('', [$alertinator, 'check']);
       $this->expectOutputEquals('', [$alertinator, 'check']);
       $this->expectOutputEquals('', [$alertinator, 'check']);
-      
+
       // The 5th alert should fire an email.
       $this->expectOutputStartsAndEndsWith(
          "Sending message Threshold of 5 reached at",
          ": Fail Five Times Test to alice@example.com via email.\n",
          [$alertinator, 'check']
       );
-      
+
       // Clear #1...
       $this->expectOutputString('');
       $alertinator->check();
-      
+
       // The 2nd clear should fire an email.
       $this->expectOutputStartsAndEndsWith(
          "Sending message The alert 'AlertinatorTest::failFiveTimes' was cleared at",
          "to alice@example.com via email.\n",
          [$alertinator, 'check']
       );
-      
+
       // Make sure everything was deleted.
       $this->assertEmpty($alertinator->logger->isInAlert('AlertinatorTest::failFiveTimes'));
-      
-      
+
+
       // Now let's simulate a failure state that "bounces" between fail and
       // success:
       $alertinator = new AlertinatorMocker([
@@ -289,7 +289,7 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
          ],
       ]);
       $alertinator->logger->safelyResetAlerts(key($alertinator->checks));
-      
+
       // TODO: As you can see, this state is (maybe?) not handled well.
       // @see Alertinator::notifyClear()
       for ($i = 0; $i < 19; $i++) {
@@ -411,7 +411,7 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
       $this->expectOutputEquals('', [$alertinator, 'check']);
 
    }
-   
+
    /**
     * Fail 4 times, then pass indefinitely.
     */
@@ -435,7 +435,7 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
          throw new AlertinatorCriticalException('Fail Five Times Test');
       }
    }
-   
+
    /**
     * Alternates between 3 fail/3 passes for 4 6-check cycles, then passes indefinitely.
    */
@@ -483,7 +483,7 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
 
       $this->assertEquals($expected, $output);
    }
-   
+
    /**
     * Seems silly, but failure and reset messages have timestamps in the middle
     * of them which would be cumbersome to persist. Instead, we can check the


### PR DESCRIPTION
Our version of the twilio-php library was way out of date and would error out.

This updates it and the tests to the newest version (6.6.0). This also adds some more type hints so we can be more confident. Lastly, this removes an extraneous url-generation step that the old version of the library required.

Connects https://github.com/iFixit/ifixit/issues/33037
