### PR TITLE
Test on PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ language: php
 php:
   - 7.3
   - 7.4
+  - 8.0
 script: phpunit AlertinatorTest.php

--- a/AlertinatorTest.php
+++ b/AlertinatorTest.php
@@ -477,7 +477,7 @@ class AlertinatorTest extends PHPUnit\Framework\TestCase {
     * This is an example of an alert-checking function with an error in it.
     */
    public static function buggyCheck() {
-      sdf;
+      trigger_error('sdf', E_USER_WARNING);
    }
 
    /**


### PR DESCRIPTION
I had to update one test to get it passing PHP 8. Undefined constant changed from a warning to an error in PHP 8. To make sure we are testing the same thing on PHP 7 and 8, this changes it to just explicitly trigger a warning.

cr_req 1
qa_req 0

Connects https://github.com/iFixit/ifixit/issues/37333